### PR TITLE
Added missing pthread linking_lib to ExampleLogger.

### DIFF
--- a/AVSUtils/examples/ExampleLogger/src/CMakeLists.txt
+++ b/AVSUtils/examples/ExampleLogger/src/CMakeLists.txt
@@ -1,5 +1,5 @@
+find_package(Threads ${THREADS_PACKAGE_CONFIG})
 add_library(ExampleLogger SHARED ExampleLogger.cpp)
 target_include_directories(ExampleLogger PUBLIC
         "${AVSUtils_SOURCE_DIR}/examples/ExampleLogger/include")
-target_link_libraries(ExampleLogger AVSUtils)
-
+target_link_libraries(ExampleLogger ${CMAKE_THREAD_LIBS_INIT} AVSUtils)


### PR DESCRIPTION
CMake fix to add thread related link_library for #3 issue.