### PR TITLE
Added handling of first directive SetEndPoint, it raises Exception.

### DIFF
--- a/Integration/test/SpeechSynthesizerIntegrationTest.cpp
+++ b/Integration/test/SpeechSynthesizerIntegrationTest.cpp
@@ -851,6 +851,8 @@ TEST_F(SpeechSynthesizerTest, handleOneSpeech) {
 
     // Wait for the directive to route through to our handler.
     TestDirectiveHandler::DirectiveParams params = m_directiveHandler->waitForNext(WAIT_FOR_TIMEOUT_DURATION);
+    ASSERT_EQ(params.type, TestDirectiveHandler::DirectiveParams::Type::EXCEPTION);
+    params = m_directiveHandler->waitForNext(WAIT_FOR_TIMEOUT_DURATION);
     ASSERT_EQ(params.type, TestDirectiveHandler::DirectiveParams::Type::PREHANDLE);
     params = m_directiveHandler->waitForNext(WAIT_FOR_TIMEOUT_DURATION);
     ASSERT_EQ(params.type, TestDirectiveHandler::DirectiveParams::Type::HANDLE);


### PR DESCRIPTION
While running these tests these is the order in which I receive directives from AVS:

- Name: SetEndpoint Type: EXCEPTION
- Name: SetMute Type: PREHANDLE
- Name: SetMute Type: HANDLE 

As there is no registerHandler call for SetEndPoint, this directive causes an Exception. I greped (`grep -r SetEndpoint alexa-client-sdk/*`) through the repo to locate any handling for such a directive but found none. Adding these additional handling of directive makes sure that this test passes. Do let me know if I am missing something or wrong somewhere in understanding the working of directives.