### PR TITLE
Update pi.sh to use shallow clones

### DIFF
--- a/tools/Install/pi.sh
+++ b/tools/Install/pi.sh
@@ -64,7 +64,7 @@ build_kwd_engine() {
   echo
 
   cd $THIRD_PARTY_PATH
-  git clone git://github.com/Sensory/alexa-rpi.git
+  git clone --depth 1 git://github.com/Sensory/alexa-rpi.git
   bash ./alexa-rpi/bin/license.sh
 }
 


### PR DESCRIPTION
Shallow clones are faster and do not require pulling in the entire history, I would not expect the installer to edit the code and make new commits straight from the Pi.