### PR TITLE
Fix build error in BlueZDeviceManager

### DIFF
--- a/BluetoothImplementations/BlueZ/src/BlueZDeviceManager.cpp
+++ b/BluetoothImplementations/BlueZ/src/BlueZDeviceManager.cpp
@@ -266,7 +266,7 @@ void BlueZDeviceManager::onMediaStreamPropertyChanged(const std::string& path, c
     ACSDK_DEBUG5(LX(__func__).d("mediaStreamUuid", uuid));
 
     char* newStateStr;
-    avsCommon::utils::bluetooth::MediaStreamingState newState;
+    avsCommon::utils::bluetooth::MediaStreamingState newState = avsCommon::utils::bluetooth::MediaStreamingState::IDLE;
     if (changesMap.getCString(MEDIATRANSPORT_PROPERTY_STATE, &newStateStr)) {
         ACSDK_DEBUG5(LX("Media transport state changed").d("newState", newStateStr));
 


### PR DESCRIPTION
Variable 'newState' may be used uninitialized

Signed-off-by: Phong LE <duphong.le@gmail.com>