### PR TITLE
Added virtual SettingInterface default destructor

### DIFF
--- a/Settings/include/Settings/SettingInterface.h
+++ b/Settings/include/Settings/SettingInterface.h
@@ -49,6 +49,11 @@ public:
     using ObserverType = SettingObserverInterface<SettingInterface<ValueType>>;
 
     /**
+     * Destructor.
+     */
+    virtual ~SettingInterface() = default;
+
+    /**
      * Request to set the managed setting to the given @c value. Note that this is an asynchronous operation.
      *
      * @param value The target value.


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/alexa/avs-device-sdk/issues/1245
https://github.com/alexa/avs-device-sdk/issues/1136
https://github.com/alexa/avs-device-sdk/issues/1161
https://github.com/alexa/avs-device-sdk/issues/1165

*Description of changes:*
Added virtual destructor for `SettingInterface`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
