### PR TITLE
Avoiding deadlock in SQLiteDeviceSettingStorage::open()

### DIFF
--- a/Settings/src/Storage/SQLiteDeviceSettingStorage.cpp
+++ b/Settings/src/Storage/SQLiteDeviceSettingStorage.cpp
@@ -114,7 +114,9 @@ bool SQLiteDeviceSettingStorage::open() {
     // At this point, database is open.
     if (!m_db.tableExists(DEVICE_SETTINGS_TABLE_NAME) && !createSettingsTable()) {
         ACSDK_ERROR(LX("openFailed").m("Cannot create " + DEVICE_SETTINGS_TABLE_NAME + " table"));
-        close();
+        // close(); Can not be called from here because it will cause dead lock.
+        // Alternative is to unlock before calling.
+        m_db.close();
         return false;
     }
 


### PR DESCRIPTION
close() acquires same lock that is taken in open(). This is causing dead lock.
We can either call m_db.close() directly from open().
Or release lock before calling close().

This is error case scenario, and is sometimes triggered on SampleClient restart.
Forcing this state can be achieved by fast manual client restart.
