### PR TITLE
Added SeekFunction callback to CURL API 

### DIFF
--- a/ACL/include/ACL/Transport/DownchannelHandler.h
+++ b/ACL/include/ACL/Transport/DownchannelHandler.h
@@ -67,6 +67,7 @@ private:
     /// @{
     std::vector<std::string> getRequestHeaderLines() override;
     avsCommon::utils::http2::HTTP2SendDataResult onSendData(char* bytes, size_t size) override;
+    int seek(int64_t offset, int origin) override;
     /// @}
 
     /// @name MimeResponseStatusHandlerInterface

--- a/ACL/include/ACL/Transport/MessageRequestHandler.h
+++ b/ACL/include/ACL/Transport/MessageRequestHandler.h
@@ -88,6 +88,7 @@ private:
     std::vector<std::string> getRequestHeaderLines() override;
     avsCommon::utils::http2::HTTP2GetMimeHeadersResult getMimePartHeaderLines() override;
     avsCommon::utils::http2::HTTP2SendDataResult onSendMimePartData(char* bytes, size_t size) override;
+    int seek(int64_t offset, int origin) override;
     /// @}
 
     /// @name MimeResponseStatusHandlerInterface

--- a/ACL/include/ACL/Transport/PingHandler.h
+++ b/ACL/include/ACL/Transport/PingHandler.h
@@ -64,6 +64,7 @@ private:
     /// @{
     std::vector<std::string> getRequestHeaderLines() override;
     avsCommon::utils::http2::HTTP2SendDataResult onSendData(char* bytes, size_t size) override;
+    int seek(int64_t offset, int origin) override;
     /// @}
 
     /// @name HTTP2ResponseSinkInterface methods

--- a/ACL/src/Transport/DownchannelHandler.cpp
+++ b/ACL/src/Transport/DownchannelHandler.cpp
@@ -93,6 +93,11 @@ HTTP2SendDataResult DownchannelHandler::onSendData(char* bytes, size_t size) {
     return HTTP2SendDataResult::COMPLETE;
 }
 
+int DownchannelHandler::seek(int64_t offset, int origin) {
+    ACSDK_DEBUG9(LX(__func__).d("offset", offset).d("origin", origin));
+    return 0; // OK_SUCCESS
+}
+
 DownchannelHandler::DownchannelHandler(
     std::shared_ptr<ExchangeHandlerContextInterface> context,
     const std::string& authToken) :

--- a/ACL/src/Transport/MessageRequestHandler.cpp
+++ b/ACL/src/Transport/MessageRequestHandler.cpp
@@ -236,6 +236,30 @@ HTTP2SendDataResult MessageRequestHandler::onSendMimePartData(char* bytes, size_
     return HTTP2SendDataResult::ABORT;
 }
 
+int MessageRequestHandler::seek(int64_t offset, int origin) {
+    ACSDK_INFO(LX(__func__).d("offset", "offset").d("origin", origin));
+    if (offset < 0) {
+        ACSDK_WARN(LX(__func__).m("Cannot seek to negative value"));
+        return 2; // Can't seek
+    }
+    bool success = false;
+    switch (origin) {
+        case SEEK_SET:
+            success = m_namedReader->reader->seek(offset);
+            break;
+        default:
+            return 2; // Can't seek
+    }
+
+    if (success) {
+        ACSDK_DEBUG9(LX(__func__).m("Seek Succeeded!"));
+        return 0; // Seek succeeded
+    } else {
+        ACSDK_DEBUG9(LX(__func__).m("Seek Failed"));
+        return 1; // Seek failed
+    }
+}
+
 void MessageRequestHandler::onActivity() {
     m_context->onActivity();
 }

--- a/ACL/src/Transport/PingHandler.cpp
+++ b/ACL/src/Transport/PingHandler.cpp
@@ -106,6 +106,11 @@ HTTP2SendDataResult PingHandler::onSendData(char* bytes, size_t size) {
     return HTTP2SendDataResult::COMPLETE;
 }
 
+int PingHandler::seek(int64_t offset, int origin) {
+    ACSDK_DEBUG9(LX(__func__).d("offset", offset).d("origin", origin));
+    return 0; // OK_SUCCESS
+}
+
 bool PingHandler::onReceiveResponseCode(long responseCode) {
     ACSDK_DEBUG5(LX(__func__).d("responseCode", responseCode));
 

--- a/AVSCommon/Utils/include/AVSCommon/Utils/HTTP2/HTTP2MimeRequestEncoder.h
+++ b/AVSCommon/Utils/include/AVSCommon/Utils/HTTP2/HTTP2MimeRequestEncoder.h
@@ -52,6 +52,7 @@ public:
     /// @name HTTP2RequestSourceInterface methods.
     /// @{
     HTTP2SendDataResult onSendData(char* bytes, size_t size) override;
+    int seek(int64_t offset, int origin) override;
     std::vector<std::string> getRequestHeaderLines() override;
     /// @}
 

--- a/AVSCommon/Utils/include/AVSCommon/Utils/HTTP2/HTTP2MimeRequestSourceInterface.h
+++ b/AVSCommon/Utils/include/AVSCommon/Utils/HTTP2/HTTP2MimeRequestSourceInterface.h
@@ -74,6 +74,15 @@ public:
      * @see HTTPSendMimePartDataResult.
      */
     virtual HTTP2SendDataResult onSendMimePartData(char* bytes, size_t size) = 0;
+
+    /**
+     * Seeks the current data source
+     *
+     * @param offset number of bytes to seek
+     * @param origin SEEK_SET, SEEK_CUR or SEEK_END
+     * @return 0, indicating success, 1, indicating failure, or 2 indicating unable to seek
+     */
+    virtual int seek(int64_t offset, int origin) = 0;
 };
 
 }  // namespace http2

--- a/AVSCommon/Utils/include/AVSCommon/Utils/HTTP2/HTTP2RequestSourceInterface.h
+++ b/AVSCommon/Utils/include/AVSCommon/Utils/HTTP2/HTTP2RequestSourceInterface.h
@@ -59,6 +59,15 @@ public:
      * @return Result indicating the disposition of the operation and number of bytes copied.  @see HTTPSendDataResult.
      */
     virtual HTTP2SendDataResult onSendData(char* bytes, size_t size) = 0;
+
+    /**
+     * Seeks the current data source
+     *
+     * @param offset number of bytes to seek
+     * @param origin SEEK_SET, SEEK_CUR or SEEK_END
+     * @return 0, indicating success, 1, indicating failure, or 2 indicating unable to seek
+     */
+    virtual int seek(int64_t offset, int origin) = 0;
 };
 
 }  // namespace http2

--- a/AVSCommon/Utils/include/AVSCommon/Utils/LibcurlUtils/CurlEasyHandleWrapper.h
+++ b/AVSCommon/Utils/include/AVSCommon/Utils/LibcurlUtils/CurlEasyHandleWrapper.h
@@ -64,6 +64,18 @@ public:
     using CurlDebugCallback =
         int (*)(CURL* handle, curl_infotype infoType, char* buffer, size_t blockSize, void* userData);
 
+
+    /**
+     * Callback to the seek function
+     *
+     * https://curl.haxx.se/libcurl/c/CURLOPT_SEEKFUNCTION.html
+     *
+     * @param userp Some user data passed in with CURLOPT_SEEKDATA
+     * @param offset Offset or index to seek to
+     * @param origin Always SEEK_SET from <stdio.h>
+     */
+    using CurlSeekCallback = int (*)(void *userp, curl_off_t offset, int origin);
+
     /**
      * Definitions for HTTP action types
      */
@@ -212,6 +224,16 @@ public:
      * @return Whether the addition was successful
      */
     bool setReadCallback(CurlCallback callback, void* userData);
+
+    /**
+     * Sets the callback to call when libcurl needs to retry
+     * sending post data
+     *
+     * @param callback A function pointer to the seek callback
+     * @param userData Any data to be passed to the callback
+     * @return Whether the addition was successful
+     */
+    bool setSeekCallback(CurlSeekCallback callback, void* userData);
 
     /**
      * Helper function for calling curl_easy_setopt and checking the result.

--- a/AVSCommon/Utils/include/AVSCommon/Utils/LibcurlUtils/LibcurlHTTP2Request.h
+++ b/AVSCommon/Utils/include/AVSCommon/Utils/LibcurlUtils/LibcurlHTTP2Request.h
@@ -149,6 +149,20 @@ private:
     static size_t readCallback(char* data, size_t size, size_t nmemb, void* userData);
 
     /**
+     * Callback that gets executed when curl needs to retry sending data
+     *
+     * @see CurlEasyHandleWrapper::CurlSeekCallback for details
+     * The function shall work like fseek(3) or lseek(3) and it gets SEEK_SET, SEEK_CUR or SEEK_END as argument for
+     * origin, although libcurl currently only passes SEEK_SET.
+     *
+     * @param userData  Context passed back from @c libcurl.  Should always be a pointer to @c LibcurlHTTP2Request.
+     * @param offset offset in bytes of the data source
+     * @param origin always SEEK_SET from <stdio.h>
+     * @return CURL_SEEKFUNC_OK(0) for success, CURL_SEEKFUNC_FAIL(1) for fail, CURL_SEEKFUNC_CANTSEEK(2) for can't seek
+     */
+    static int seekCallback(void *userData, curl_off_t offset, int origin);
+
+    /**
      * Returns the HTTP response code to this request.
      *
      * @returns The HTTP response code if one has been received, 0 if not, and < 0 if there is an error

--- a/AVSCommon/Utils/src/HTTP2/HTTP2MimeRequestEncoder.cpp
+++ b/AVSCommon/Utils/src/HTTP2/HTTP2MimeRequestEncoder.cpp
@@ -239,6 +239,11 @@ HTTP2SendDataResult HTTP2MimeRequestEncoder::onSendData(char* bytes, size_t size
     }
 }
 
+int HTTP2MimeRequestEncoder::seek(int64_t offset, int origin) {
+    ACSDK_DEBUG9(LX(__func__).d("offset", offset).d("origin", origin));
+    return m_source->seek(offset, origin);
+}
+
 std::vector<std::string> HTTP2MimeRequestEncoder::getRequestHeaderLines() {
     ACSDK_DEBUG9(LX(__func__));
     if (m_source) {

--- a/AVSCommon/Utils/src/LibcurlUtils/CurlEasyHandleWrapper.cpp
+++ b/AVSCommon/Utils/src/LibcurlUtils/CurlEasyHandleWrapper.cpp
@@ -270,6 +270,10 @@ bool CurlEasyHandleWrapper::setReadCallback(CurlCallback callback, void* userDat
     return setopt(CURLOPT_READFUNCTION, callback) && (!userData || setopt(CURLOPT_READDATA, userData));
 }
 
+bool CurlEasyHandleWrapper::setSeekCallback(CurlSeekCallback callback, void* userData) {
+    return setopt(CURLOPT_SEEKFUNCTION, callback) && (!userData || setopt(CURLOPT_SEEKDATA, userData));
+}
+
 std::string CurlEasyHandleWrapper::urlEncode(const std::string& in) const {
     std::string result;
     auto temp = curl_easy_escape(m_handle, in.c_str(), 0);

--- a/AVSCommon/Utils/test/AVSCommon/Utils/HTTP2/MockHTTP2MimeRequestEncodeSource.h
+++ b/AVSCommon/Utils/test/AVSCommon/Utils/HTTP2/MockHTTP2MimeRequestEncodeSource.h
@@ -44,6 +44,7 @@ public:
     /// @{
     HTTP2GetMimeHeadersResult getMimePartHeaderLines() override;
     HTTP2SendDataResult onSendMimePartData(char* bytes, size_t size) override;
+    int seek(int64_t offset, int origin) override;
     std::vector<std::string> getRequestHeaderLines() override;
     /// @}
 

--- a/AVSCommon/Utils/test/Common/MockHTTP2MimeRequestEncodeSource.cpp
+++ b/AVSCommon/Utils/test/Common/MockHTTP2MimeRequestEncodeSource.cpp
@@ -64,6 +64,10 @@ HTTP2SendDataResult MockHTTP2MimeRequestEncodeSource::onSendMimePartData(char* b
     return HTTP2SendDataResult(bytesToWrite);
 }
 
+int MockHTTP2MimeRequestEncodeSource::seek(int64_t offset, int origin) {
+    return 2; // NOT IMPLEMENTED IN TEST
+}
+
 std::vector<std::string> MockHTTP2MimeRequestEncodeSource::getRequestHeaderLines() {
     return std::vector<std::string>();
 }


### PR DESCRIPTION
**Issue**
- About 1 in 10 Alexa requests fail on mobile devices. 
- Requests generally fail with one of two errors: [curl error code 56](https://curl.haxx.se/libcurl/c/libcurl-errors.html#CURLERECVERROR) which is "receive error" or [curl error code 65](https://curl.haxx.se/libcurl/c/libcurl-errors.html#CURLESENDFAILREWIND) which is "rewind failed"
- I turned on `ACSDK_EMIT_SENSITIVE_LOGS` to output curl error messages and me help investigate what was going on
- It looks like the errors (both 56 and 65) are accompanied with this message `"necessary data rewind wasn't possible"`:

```
CurlEasyHandleWrapper:libcurl:id=AVSEvent-619,text=necessary data rewind wasn't possible
LibcurlHTTP2Request:getResponseCode:responseCode=0
LibcurlHTTP2Connection:streamFinished:streamId=AVSEvent-619,result=Error,CURLcode=56
```

 - It seems that implementing the [`CURLOPT_SEEKFUNCTION`](https://curl.haxx.se/libcurl/c/CURLOPT_SEEKFUNCTION.html) and setting [`CURLOPT_SEEKDATA`](https://curl.haxx.se/libcurl/c/CURLOPT_SEEKDATA.html) will solve this problem
 - This is a fairly simple change, as [`AttachmentReader` already has a seek function](https://github.com/alexa/avs-device-sdk/blob/master/AVSCommon/AVS/include/AVSCommon/AVS/Attachment/AttachmentReader.h#L94) which mirrors the implementation of `CURLOPT_SEEKFUNCTION`: Both expect to be able to set the absolute index of the buffer instead of changing the cursor by some delta.

**Description of changes:**

 1. Implemented callback functions for `CURLOPT_SEEKFUNCTION`
 2. Call `seek` on `AttachmentReader` when called from curl