### PR TITLE
Adds rewind function to allow curl seek and retry sending data to server

### DIFF
--- a/ACL/include/ACL/Transport/DownchannelHandler.h
+++ b/ACL/include/ACL/Transport/DownchannelHandler.h
@@ -67,6 +67,7 @@ private:
     /// @{
     std::vector<std::string> getRequestHeaderLines() override;
     avsCommon::utils::http2::HTTP2SendDataResult onSendData(char* bytes, size_t size) override;
+    bool rewindData() override;
     /// @}
 
     /// @name MimeResponseStatusHandlerInterface

--- a/ACL/include/ACL/Transport/MessageRequestHandler.h
+++ b/ACL/include/ACL/Transport/MessageRequestHandler.h
@@ -88,6 +88,7 @@ private:
     std::vector<std::string> getRequestHeaderLines() override;
     avsCommon::utils::http2::HTTP2GetMimeHeadersResult getMimePartHeaderLines() override;
     avsCommon::utils::http2::HTTP2SendDataResult onSendMimePartData(char* bytes, size_t size) override;
+    bool rewindData() override;
     /// @}
 
     /// @name MimeResponseStatusHandlerInterface
@@ -124,6 +125,9 @@ private:
 
     /// Response code received through @c onReciveResponseCode (or zero).
     long m_responseCode;
+
+    /// Number of bytes read from the attachment
+    int64_t m_bytesReadFromAttachmentReader;
 };
 
 }  // namespace acl

--- a/ACL/include/ACL/Transport/PingHandler.h
+++ b/ACL/include/ACL/Transport/PingHandler.h
@@ -64,6 +64,7 @@ private:
     /// @{
     std::vector<std::string> getRequestHeaderLines() override;
     avsCommon::utils::http2::HTTP2SendDataResult onSendData(char* bytes, size_t size) override;
+    bool rewindData() override;
     /// @}
 
     /// @name HTTP2ResponseSinkInterface methods

--- a/ACL/src/Transport/DownchannelHandler.cpp
+++ b/ACL/src/Transport/DownchannelHandler.cpp
@@ -93,6 +93,14 @@ HTTP2SendDataResult DownchannelHandler::onSendData(char* bytes, size_t size) {
     return HTTP2SendDataResult::COMPLETE;
 }
 
+bool DownchannelHandler::rewindData() {
+    ACSDK_DEBUG9(LX(__func__));
+    // no-op: this function is only called
+    // during data upload and this class
+    // does not upload data
+    return true;
+}
+
 DownchannelHandler::DownchannelHandler(
     std::shared_ptr<ExchangeHandlerContextInterface> context,
     const std::string& authToken) :

--- a/ACL/src/Transport/MessageRequestHandler.cpp
+++ b/ACL/src/Transport/MessageRequestHandler.cpp
@@ -135,7 +135,8 @@ MessageRequestHandler::MessageRequestHandler(
         m_countOfPartsSent{0},
         m_wasMessageRequestAcknowledgeReported{false},
         m_wasMessageRequestFinishedReported{false},
-        m_responseCode{0} {
+        m_responseCode{0},
+        m_bytesReadFromAttachmentReader{0} {
     ACSDK_DEBUG7(LX(__func__).d("context", context.get()).d("messageRequest", messageRequest.get()));
 }
 
@@ -204,6 +205,7 @@ HTTP2SendDataResult MessageRequestHandler::onSendMimePartData(char* bytes, size_
     } else if (m_namedReader) {
         auto readStatus = AttachmentReader::ReadStatus::OK;
         auto bytesRead = m_namedReader->reader->read(bytes, size, &readStatus);
+        m_bytesReadFromAttachmentReader += bytesRead;
         ACSDK_DEBUG9(LX("attachmentRead").d("readStatus", (int)readStatus).d("bytesRead", bytesRead));
         switch (readStatus) {
             // The good cases.
@@ -234,6 +236,25 @@ HTTP2SendDataResult MessageRequestHandler::onSendMimePartData(char* bytes, size_
 
     ACSDK_ERROR(LX("onSendMimePartDataFailed").d("reason", "noMoreAttachments"));
     return HTTP2SendDataResult::ABORT;
+}
+
+bool MessageRequestHandler::rewindData() {
+    ACSDK_DEBUG9(LX(__func__).d("m_bytesReadFromAttachmentReader", m_bytesReadFromAttachmentReader));
+    if (!m_namedReader->reader->seekRelativeBytes(-m_bytesReadFromAttachmentReader)) {
+        ACSDK_ERROR(LX(__func__).m("Could not seek!"));
+        return false;
+    }
+
+    // Reset mime parts
+    m_jsonNext = m_json.c_str();
+    m_countOfJsonBytesLeft = m_json.size();
+    m_countOfPartsSent = 0;
+    m_wasMessageRequestAcknowledgeReported = false;
+    m_wasMessageRequestFinishedReported = false;
+    m_responseCode = 0;
+    m_bytesReadFromAttachmentReader = 0;
+
+    return true;
 }
 
 void MessageRequestHandler::onActivity() {

--- a/ACL/src/Transport/PingHandler.cpp
+++ b/ACL/src/Transport/PingHandler.cpp
@@ -106,6 +106,14 @@ HTTP2SendDataResult PingHandler::onSendData(char* bytes, size_t size) {
     return HTTP2SendDataResult::COMPLETE;
 }
 
+bool PingHandler::rewindData() {
+    ACSDK_DEBUG9(LX(__func__));
+    // no-op: this function is only called
+    // during data upload and this class
+    // does not upload data
+    return true;
+}
+
 bool PingHandler::onReceiveResponseCode(long responseCode) {
     ACSDK_DEBUG5(LX(__func__).d("responseCode", responseCode));
 

--- a/AVSCommon/AVS/include/AVSCommon/AVS/Attachment/AttachmentReader.h
+++ b/AVSCommon/AVS/include/AVSCommon/AVS/Attachment/AttachmentReader.h
@@ -94,6 +94,16 @@ public:
     virtual bool seek(uint64_t offset) = 0;
 
     /**
+     * Seeks a relative number of bytes from the
+     * current position in the stream
+     *
+     * @param offset The offset (in bytes! not words!) to seek to within the @c Attachment.
+     * @return @c true if the specified position points at unexpired data, or @c false otherwise. Note that it is valid
+     * to seek into a future index that has not been written to yet.
+     */
+    virtual bool seekRelativeBytes(int64_t offsetInBytes) = 0;
+
+    /**
      * Utility function to return the number of bytes in an attachment.
      *
      * @return Number of unread bytes in the attachment by this attachment reader.

--- a/AVSCommon/AVS/include/AVSCommon/AVS/Attachment/InProcessAttachmentReader.h
+++ b/AVSCommon/AVS/include/AVSCommon/AVS/Attachment/InProcessAttachmentReader.h
@@ -74,6 +74,8 @@ public:
 
     bool seek(uint64_t offset) override;
 
+    bool seekRelativeBytes(int64_t offsetInBytes) override;
+
     uint64_t getNumUnreadBytes() override;
 
 private:

--- a/AVSCommon/AVS/src/Attachment/InProcessAttachmentReader.cpp
+++ b/AVSCommon/AVS/src/Attachment/InProcessAttachmentReader.cpp
@@ -190,6 +190,21 @@ bool InProcessAttachmentReader::seek(uint64_t offset) {
     return false;
 }
 
+bool InProcessAttachmentReader::seekRelativeBytes(int64_t offsetInBytes) {
+    if (m_reader) {
+        int64_t wordOffset = offsetInBytes / static_cast<int64_t>(m_reader->getWordSize());
+        ACSDK_DEBUG9(LX("seekRelativeBytes").d("wordOffset", wordOffset));
+        if (wordOffset < 0) {
+            // Seek back
+            return m_reader->seek(-wordOffset, utils::sds::InProcessSDS::Reader::Reference::BEFORE_READER);
+        } else {
+            // Seek forward
+            return m_reader->seek(wordOffset, utils::sds::InProcessSDS::Reader::Reference::AFTER_READER);
+        }
+    }
+    return false;
+}
+
 uint64_t InProcessAttachmentReader::getNumUnreadBytes() {
     if (m_reader) {
         return m_reader->tell(utils::sds::InProcessSDS::Reader::Reference::BEFORE_WRITER);

--- a/AVSCommon/Utils/include/AVSCommon/Utils/HTTP2/HTTP2MimeRequestEncoder.h
+++ b/AVSCommon/Utils/include/AVSCommon/Utils/HTTP2/HTTP2MimeRequestEncoder.h
@@ -52,6 +52,7 @@ public:
     /// @name HTTP2RequestSourceInterface methods.
     /// @{
     HTTP2SendDataResult onSendData(char* bytes, size_t size) override;
+    bool rewindData() override;
     std::vector<std::string> getRequestHeaderLines() override;
     /// @}
 

--- a/AVSCommon/Utils/include/AVSCommon/Utils/HTTP2/HTTP2MimeRequestSourceInterface.h
+++ b/AVSCommon/Utils/include/AVSCommon/Utils/HTTP2/HTTP2MimeRequestSourceInterface.h
@@ -74,6 +74,14 @@ public:
      * @see HTTPSendMimePartDataResult.
      */
     virtual HTTP2SendDataResult onSendMimePartData(char* bytes, size_t size) = 0;
+
+    /**
+     * Rewinds the data to the beginning. Used for uploading
+     * data to the server again if there is a connection issue.
+     *
+     * @return true, if the rewind was successful. False otherwise
+     */
+    virtual bool rewindData() = 0;
 };
 
 }  // namespace http2

--- a/AVSCommon/Utils/include/AVSCommon/Utils/HTTP2/HTTP2RequestSourceInterface.h
+++ b/AVSCommon/Utils/include/AVSCommon/Utils/HTTP2/HTTP2RequestSourceInterface.h
@@ -59,6 +59,14 @@ public:
      * @return Result indicating the disposition of the operation and number of bytes copied.  @see HTTPSendDataResult.
      */
     virtual HTTP2SendDataResult onSendData(char* bytes, size_t size) = 0;
+
+    /**
+     * Rewinds the data to the beginning. Used for uploading
+     * data to the server again if there is a connection issue.
+     *
+     * @return true, if the rewind was successful. False otherwise
+     */
+    virtual bool rewindData() = 0;
 };
 
 }  // namespace http2

--- a/AVSCommon/Utils/include/AVSCommon/Utils/LibcurlUtils/CurlEasyHandleWrapper.h
+++ b/AVSCommon/Utils/include/AVSCommon/Utils/LibcurlUtils/CurlEasyHandleWrapper.h
@@ -64,6 +64,18 @@ public:
     using CurlDebugCallback =
         int (*)(CURL* handle, curl_infotype infoType, char* buffer, size_t blockSize, void* userData);
 
+
+    /**
+     * Callback signature of the libcurl SEEK function
+     *
+     * https://curl.haxx.se/libcurl/c/CURLOPT_SEEKFUNCTION.html
+     *
+     * @param userp User data as set with CURLOPT_SEEKDATA
+     * @param offset Absolute index if `SEEK_SET`. Relative delta if `SEEK_CUR` or `SEEK_END`
+     * @param origin Always SEEK_SET from <stdio.h>
+     */
+    using CurlSeekCallback = int (*)(void *userp, curl_off_t offset, int origin);
+
     /**
      * Definitions for HTTP action types
      */
@@ -212,6 +224,16 @@ public:
      * @return Whether the addition was successful
      */
     bool setReadCallback(CurlCallback callback, void* userData);
+
+    /**
+     * Sets the callback to call when libcurl needs to retry
+     * sending post data
+     *
+     * @param callback A function pointer to the seek callback
+     * @param userData Any data to be passed to the callback
+     * @return Whether the addition was successful
+     */
+    bool setSeekCallback(CurlSeekCallback callback, void* userData);
 
     /**
      * Helper function for calling curl_easy_setopt and checking the result.

--- a/AVSCommon/Utils/include/AVSCommon/Utils/LibcurlUtils/LibcurlHTTP2Request.h
+++ b/AVSCommon/Utils/include/AVSCommon/Utils/LibcurlUtils/LibcurlHTTP2Request.h
@@ -149,6 +149,20 @@ private:
     static size_t readCallback(char* data, size_t size, size_t nmemb, void* userData);
 
     /**
+     * Callback that gets executed when curl needs to retry sending data
+     *
+     * @see CurlEasyHandleWrapper::CurlSeekCallback for details
+     * The function shall work like fseek(3) or lseek(3) and it gets SEEK_SET, SEEK_CUR or SEEK_END as argument for
+     * origin, although libcurl currently only passes SEEK_SET.
+     *
+     * @param userData  Context passed back from @c libcurl.  Should always be a pointer to @c LibcurlHTTP2Request.
+     * @param offset Absolute index if `SEEK_SET`. Relative delta if `SEEK_CUR` or `SEEK_END`
+     * @param origin always SEEK_SET from <stdio.h>
+     * @return CURL_SEEKFUNC_OK(0) for success, CURL_SEEKFUNC_FAIL(1) for fail, CURL_SEEKFUNC_CANTSEEK(2) for can't seek
+     */
+    static int seekCallback(void *userData, curl_off_t offset, int origin);
+
+    /**
      * Returns the HTTP response code to this request.
      *
      * @returns The HTTP response code if one has been received, 0 if not, and < 0 if there is an error

--- a/AVSCommon/Utils/src/HTTP2/HTTP2MimeRequestEncoder.cpp
+++ b/AVSCommon/Utils/src/HTTP2/HTTP2MimeRequestEncoder.cpp
@@ -239,6 +239,18 @@ HTTP2SendDataResult HTTP2MimeRequestEncoder::onSendData(char* bytes, size_t size
     }
 }
 
+bool HTTP2MimeRequestEncoder::rewindData() {
+    ACSDK_DEBUG9(LX(__func__));
+    if (m_source->rewindData()) {
+        m_state = State::NEW;
+        m_getMimeHeaderLinesResult = HTTP2GetMimeHeadersResult::ABORT;
+        m_headerLine = m_getMimeHeaderLinesResult.headers.begin();
+        m_stringIndex = 0;
+        return true;
+    }
+    return false;
+}
+
 std::vector<std::string> HTTP2MimeRequestEncoder::getRequestHeaderLines() {
     ACSDK_DEBUG9(LX(__func__));
     if (m_source) {

--- a/AVSCommon/Utils/src/LibcurlUtils/CurlEasyHandleWrapper.cpp
+++ b/AVSCommon/Utils/src/LibcurlUtils/CurlEasyHandleWrapper.cpp
@@ -270,6 +270,10 @@ bool CurlEasyHandleWrapper::setReadCallback(CurlCallback callback, void* userDat
     return setopt(CURLOPT_READFUNCTION, callback) && (!userData || setopt(CURLOPT_READDATA, userData));
 }
 
+bool CurlEasyHandleWrapper::setSeekCallback(CurlSeekCallback callback, void* userData) {
+    return setopt(CURLOPT_SEEKFUNCTION, callback) && (!userData || setopt(CURLOPT_SEEKDATA, userData));
+}
+
 std::string CurlEasyHandleWrapper::urlEncode(const std::string& in) const {
     std::string result;
     auto temp = curl_easy_escape(m_handle, in.c_str(), 0);

--- a/AVSCommon/Utils/test/AVSCommon/Utils/HTTP2/MockHTTP2MimeRequestEncodeSource.h
+++ b/AVSCommon/Utils/test/AVSCommon/Utils/HTTP2/MockHTTP2MimeRequestEncodeSource.h
@@ -44,6 +44,7 @@ public:
     /// @{
     HTTP2GetMimeHeadersResult getMimePartHeaderLines() override;
     HTTP2SendDataResult onSendMimePartData(char* bytes, size_t size) override;
+    bool rewindData() override;
     std::vector<std::string> getRequestHeaderLines() override;
     /// @}
 

--- a/AVSCommon/Utils/test/Common/MockHTTP2MimeRequestEncodeSource.cpp
+++ b/AVSCommon/Utils/test/Common/MockHTTP2MimeRequestEncodeSource.cpp
@@ -64,6 +64,10 @@ HTTP2SendDataResult MockHTTP2MimeRequestEncodeSource::onSendMimePartData(char* b
     return HTTP2SendDataResult(bytesToWrite);
 }
 
+bool MockHTTP2MimeRequestEncodeSource::rewindData() {
+    return true; // NOT IMPLEMENTED IN TEST
+}
+
 std::vector<std::string> MockHTTP2MimeRequestEncodeSource::getRequestHeaderLines() {
     return std::vector<std::string>();
 }


### PR DESCRIPTION
**Issue**
 - https://github.com/alexa/avs-device-sdk/issues/1526
- About 1 in 10 Alexa requests fail on mobile devices. 
- Requests generally fail with one of two errors: [curl error code 56](https://curl.haxx.se/libcurl/c/libcurl-errors.html#CURLERECVERROR) which is "receive error" or [curl error code 65](https://curl.haxx.se/libcurl/c/libcurl-errors.html#CURLESENDFAILREWIND) which is "rewind failed"
- I turned on `ACSDK_EMIT_SENSITIVE_LOGS` to output curl error messages and me help investigate what was going on
- It looks like the errors (both 56 and 65) are accompanied with this message `"necessary data rewind wasn't possible"`:

```
CurlEasyHandleWrapper:libcurl:id=AVSEvent-619,text=necessary data rewind wasn't possible
LibcurlHTTP2Request:getResponseCode:responseCode=0
LibcurlHTTP2Connection:streamFinished:streamId=AVSEvent-619,result=Error,CURLcode=56
```

 - It seems that implementing the [`CURLOPT_SEEKFUNCTION`](https://curl.haxx.se/libcurl/c/CURLOPT_SEEKFUNCTION.html) and setting [`CURLOPT_SEEKDATA`](https://curl.haxx.se/libcurl/c/CURLOPT_SEEKDATA.html) will solve this problem
 - This is a fairly simple change, as [`AttachmentReader` already has a seek function](https://github.com/alexa/avs-device-sdk/blob/master/AVSCommon/AVS/include/AVSCommon/AVS/Attachment/AttachmentReader.h#L94) which mirrors the implementation of `CURLOPT_SEEKFUNCTION`: Both expect to be able to set the absolute index of the buffer instead of changing the cursor by some delta.

**Description of changes:**

 1. Implemented callback functions for `CURLOPT_SEEKFUNCTION`
 2. Add a `rewind` function to the read callbacks
 3. Call `seek` on `AttachmentReader` when called from curl

**Testing**:

Was able to build and run automated tests. This seems to fix the issue. No more 56 or 65 errors.