### PR TITLE
Fix build warnings

### DIFF
--- a/BluetoothImplementations/BlueZ/src/PulseAudioBluetoothInitializer.cpp
+++ b/BluetoothImplementations/BlueZ/src/PulseAudioBluetoothInitializer.cpp
@@ -57,7 +57,7 @@ static const std::chrono::seconds TIMEOUT{2};
 /**
  * Converts a pa_context_state_t enum to a string.
  */
-static std::string stateToString(pa_context_state_t state) {
+std::string stateToString(pa_context_state_t state) {
     switch (state) {
         case PA_CONTEXT_UNCONNECTED:
             return "PA_CONTEXT_UNCONNECTED";
@@ -250,6 +250,7 @@ void PulseAudioBluetoothInitializer::onModuleFound(
 
 bool PulseAudioBluetoothInitializer::updateStateLocked(const ModuleState& state, const std::string& module) {
     ModuleState currentState = ModuleState::UNKNOWN;
+    (void)currentState;
 
     if (BLUETOOTH_POLICY == module) {
         currentState = m_policyState;


### PR DESCRIPTION
In release mode, 2 warnings could lead to errors if compile flags
-Werror=unused-but-set-variable and -Werror=unused-function are enabled

Signed-off-by: Phong LE <duphong.le@gmail.com>

*Issue #, if available:*
if compile flags -Werror=unused-but-set-variable and -Werror=unused-function are enabled

*Description of changes:*
Remove static in unused function and void use for set but not used variable

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
