### PR TITLE
There is a BUG in Timer.cpp

### DIFF
--- a/AVSCommon/Utils/include/AVSCommon/Utils/Timing/Timer.h
+++ b/AVSCommon/Utils/include/AVSCommon/Utils/Timing/Timer.h
@@ -217,7 +217,7 @@ private:
 
     /// The mutex for @c m_waitCondition.
     std::mutex m_waitMutex;
-
+    std::mutex m_joinMutex;
     /// The thread to execute tasks on.
     std::thread m_thread;
 


### PR DESCRIPTION
There is a bug in the Timer. IF maney threads want to stop a timer, it maybe joinable, and then they will join at one time ,so it will crash.
There lack a lock.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
