### PR TITLE
There  is a BUG in Timer.cpp,Update Timer.cpp

### DIFF
--- a/AVSCommon/Utils/src/Timer.cpp
+++ b/AVSCommon/Utils/src/Timer.cpp
@@ -35,7 +35,7 @@ void Timer::stop() {
         }
         m_waitCondition.notify_all();
     }
-
+    std::lock_guard<std::mutex> joinLock(m_joinMutex);
     if (std::this_thread::get_id() != m_thread.get_id() && m_thread.joinable()) {
         m_thread.join();
     }


### PR DESCRIPTION
There is a bug in the Timer. IF maney threads want to stop a timer, it maybe joinable, and then they will join at one time ,so it will crash.
There lack a lock.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
