### PR TITLE
Android Microphone Configuration Fix

### DIFF
--- a/ApplicationUtilities/AndroidUtilities/include/AndroidUtilities/AndroidSLESMicrophone.h
+++ b/ApplicationUtilities/AndroidUtilities/include/AndroidUtilities/AndroidSLESMicrophone.h
@@ -57,7 +57,7 @@ public:
      *
      * @return @c true if it suceeds, and @c false if it fails.
      */
-    bool configureRecognizeMode();
+    static bool configureRecognizeMode(const SLObjectItf recorderObjectItf);
 
     /// @name MicrophoneInterface methods
     /// @{

--- a/ApplicationUtilities/AndroidUtilities/src/AndroidSLESEngine.cpp
+++ b/ApplicationUtilities/AndroidUtilities/src/AndroidSLESEngine.cpp
@@ -90,13 +90,18 @@ std::unique_ptr<AndroidSLESObject> AndroidSLESEngine::createAudioRecorder() {
     auto audioSink = AndroidSLESMicrophone::createSinkConfiguration();
     auto audioSource = AndroidSLESMicrophone::createSourceConfiguration();
 
-    constexpr uint32_t interfaceSize = 1;
-    const SLInterfaceID interfaceIDs[interfaceSize] = {SL_IID_ANDROIDSIMPLEBUFFERQUEUE};
-    const SLboolean requiredInterfaces[interfaceSize] = {SL_BOOLEAN_TRUE};
+    constexpr uint32_t interfaceSize = 2;
+    const SLInterfaceID interfaceIDs[interfaceSize] = {SL_IID_ANDROIDSIMPLEBUFFERQUEUE, SL_IID_ANDROIDCONFIGURATION};
+    const SLboolean requiredInterfaces[interfaceSize] = {SL_BOOLEAN_TRUE, SL_BOOLEAN_TRUE};
 
     SLObjectItf recorderObject;
     (*m_engine)->CreateAudioRecorder(
         m_engine, &recorderObject, &audioSource, &audioSink, interfaceSize, interfaceIDs, requiredInterfaces);
+
+    // Note: the recorder must be configured before it is realized
+    if (!AndroidSLESMicrophone::configureRecognizeMode(recorderObject)) {
+        ACSDK_WARN(LX("Failed to set Recognize mode. This might affect the voice recognition."));
+    }
 
     return AndroidSLESObject::create(recorderObject);
 }


### PR DESCRIPTION
*Description of changes:*
Currently, in the Android version of the SDK, you can see the following error lines every time the microphone is enabled:

```
2020-03-19 22:48:02.377 [ 27] W AndroidMicrophone:configureRecognizeModeFailed:reason=cannot set configuration,result=2
2020-03-19 22:48:02.377 [ 27] W AndroidMicrophone:Failed to set Recognize mode. This might affect the voice recognition.
```

This change fixes that error and properly applies the recording preset.  I found [this](https://github.com/android/ndk-samples/blob/master/audio-echo/app/src/main/cpp/audio_recorder.cpp) to be a helpful resource.

Additionally, I have switched the preset from `VOICE_RECOGNITION` to `VOICE_COMMUNICATION` to take advantage of acoustic echo cancellation, which proved to be necessary for commands like *'Alexa, what is your name?'* to work properly if a wake word library is being used.