### PR TITLE
Fix build for when Endpoint features are used but not range controller

### DIFF
--- a/SampleApp/src/SampleApplication.cpp
+++ b/SampleApp/src/SampleApplication.cpp
@@ -222,6 +222,7 @@ static const std::string SAMPLE_ENDPOINT_ADDITIONAL_ATTRIBUTE_SOFTWARE_VERSION("
 /// The custom identifier.
 static const std::string SAMPLE_ENDPOINT_ADDITIONAL_ATTRIBUTE_CUSTOM_IDENTIFIER("SampleApp");
 
+#ifdef ENDPOINT_CONTROLLERS_RANGE_CONTROLLER
 /// The range controller preset 'high'.
 static const double SAMPLE_ENDPOINT_RANGE_CONTROLLER_PRESET_HIGH = 10;
 
@@ -230,6 +231,7 @@ static const double SAMPLE_ENDPOINT_RANGE_CONTROLLER_PRESET_MEDIUM = 5;
 
 /// The range controller preset 'low'.
 static const double SAMPLE_ENDPOINT_RANGE_CONTROLLER_PRESET_LOW = 1;
+#endif
 
 /// US English locale string.
 static const std::string EN_US("en-US");


### PR DESCRIPTION
Steps to re-produce:

Enable ENDPOINT_CONTROLLERS_POWER_CONTROLLER only and try to build.

Since range controller variables are global, we get unused variables error.

*Description of changes:*

Fixes the build issue when Smart Home endpoint features are used but not Range controller

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
