### PR TITLE
Feature/ability to build static and shared

### DIFF
--- a/ACL/src/CMakeLists.txt
+++ b/ACL/src/CMakeLists.txt
@@ -1,7 +1,7 @@
 file(GLOB_RECURSE ACL_SRC "${ACL_SOURCE_DIR}/src/*.cpp")
 add_definitions("-DACSDK_LOG_MODULE=acl")
 add_definitions("-DACSDK_OPENSSL_MIN_VER_REQUIRED=${OPENSSL_MIN_VERSION}")
-add_library(ACL SHARED ${ACL_SRC})
+add_library(ACL ${AVS_DEVICE_SDK_BUILD_LIBRARY_TYPE} ${ACL_SRC})
 target_include_directories(ACL PUBLIC "${MultipartParser_SOURCE_DIR}")
 target_include_directories(ACL PUBLIC ${CURL_INCLUDE_DIRS})
 target_include_directories(ACL PUBLIC "${ACL_SOURCE_DIR}/include")

--- a/ADSL/src/CMakeLists.txt
+++ b/ADSL/src/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.1 FATAL_ERROR)
 
 find_package(Threads ${THREADS_PACKAGE_CONFIG})
 add_definitions("-DACSDK_LOG_MODULE=adsl")
-add_library(ADSL SHARED
+add_library(ADSL ${AVS_DEVICE_SDK_BUILD_LIBRARY_TYPE}
     DirectiveProcessor.cpp
     DirectiveRouter.cpp
     DirectiveSequencer.cpp

--- a/AFML/src/CMakeLists.txt
+++ b/AFML/src/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_library(AFML SHARED
+add_library(AFML ${AVS_DEVICE_SDK_BUILD_LIBRARY_TYPE}
     AudioActivityTracker.cpp
     Channel.cpp
     FocusManagementComponent.cpp

--- a/AVSCommon/CMakeLists.txt
+++ b/AVSCommon/CMakeLists.txt
@@ -6,7 +6,7 @@ add_subdirectory("AVS")
 add_subdirectory("SDKInterfaces")
 add_subdirectory("Utils")
 
-add_library(AVSCommon SHARED
+add_library(AVSCommon ${AVS_DEVICE_SDK_BUILD_LIBRARY_TYPE}
     AVS/src/AVSContext.cpp
     AVS/src/AVSDirective.cpp
     AVS/src/AVSMessage.cpp

--- a/AVSGatewayManager/src/CMakeLists.txt
+++ b/AVSGatewayManager/src/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_definitions("-DACSDK_LOG_MODULE=avsGatewayManager")
-add_library(AVSGatewayManager SHARED
+add_library(AVSGatewayManager ${AVS_DEVICE_SDK_BUILD_LIBRARY_TYPE}
     AVSGatewayManager.cpp
     Storage/AVSGatewayManagerStorage.cpp
     PostConnectVerifyGatewaySender.cpp)

--- a/ApplicationUtilities/AndroidUtilities/src/CMakeLists.txt
+++ b/ApplicationUtilities/AndroidUtilities/src/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.1 FATAL_ERROR)
 
 add_definitions("-DACSDK_LOG_MODULE=androidUtilities")
 
-add_library(AndroidUtilities SHARED
+add_library(AndroidUtilities ${AVS_DEVICE_SDK_BUILD_LIBRARY_TYPE}
         AndroidLogger.cpp
         AndroidSLESBufferQueue.cpp
         AndroidSLESEngine.cpp

--- a/ApplicationUtilities/DefaultClient/src/CMakeLists.txt
+++ b/ApplicationUtilities/DefaultClient/src/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.1 FATAL_ERROR)
 
 add_definitions("-DACSDK_LOG_MODULE=defaultClient")
-add_library(DefaultClient SHARED
+add_library(DefaultClient ${AVS_DEVICE_SDK_BUILD_LIBRARY_TYPE}
     ConnectionRetryTrigger.cpp
     DefaultClient.cpp
     DefaultClientComponent.cpp

--- a/ApplicationUtilities/Resources/Audio/src/CMakeLists.txt
+++ b/ApplicationUtilities/Resources/Audio/src/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.1 FATAL_ERROR)
 
-add_library(AudioResources SHARED
+add_library(AudioResources ${AVS_DEVICE_SDK_BUILD_LIBRARY_TYPE}
         AlertsAudioFactory.cpp
         AudioFactory.cpp
         NotificationsAudioFactory.cpp

--- a/ApplicationUtilities/SDKComponent/src/CMakeLists.txt
+++ b/ApplicationUtilities/SDKComponent/src/CMakeLists.txt
@@ -1,6 +1,6 @@
 add_definitions("-DACSDK_LOG_MODULE=SDKComponent")
 
-add_library(SDKComponent SHARED SDKComponent.cpp)
+add_library(SDKComponent ${AVS_DEVICE_SDK_BUILD_LIBRARY_TYPE} SDKComponent.cpp)
 
 target_include_directories(SDKComponent PUBLIC
     "${SDKComponent_SOURCE_DIR}/include")

--- a/ApplicationUtilities/SystemSoundPlayer/src/CMakeLists.txt
+++ b/ApplicationUtilities/SystemSoundPlayer/src/CMakeLists.txt
@@ -1,6 +1,6 @@
 add_definitions("-DACSDK_LOG_MODULE=systemSoundPlayer")
 
-add_library(SystemSoundPlayer SHARED SystemSoundPlayer.cpp)
+add_library(SystemSoundPlayer ${AVS_DEVICE_SDK_BUILD_LIBRARY_TYPE} SystemSoundPlayer.cpp)
 
 target_include_directories(SystemSoundPlayer PUBLIC
     "${SystemSoundPlayer_SOURCE_DIR}/include")

--- a/BluetoothImplementations/BlueZ/src/CMakeLists.txt
+++ b/BluetoothImplementations/BlueZ/src/CMakeLists.txt
@@ -1,6 +1,6 @@
 add_definitions("-DACSDK_LOG_MODULE=bluetoothImplementationsBlueZ")
 
-add_library(BluetoothImplementationsBlueZ SHARED
+add_library(BluetoothImplementationsBlueZ ${AVS_DEVICE_SDK_BUILD_LIBRARY_TYPE}
     BlueZA2DPSink.cpp
     BlueZA2DPSource.cpp
     BlueZAVRCPController.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,12 @@
 cmake_minimum_required(VERSION 3.1 FATAL_ERROR)
 
+option(BUILD_STATIC_LIBS "Build static library" OFF)
+if (BUILD_STATIC_LIBS)
+	set(AVS_DEVICE_SDK_BUILD_LIBRARY_TYPE STATIC)
+else()
+	set(AVS_DEVICE_SDK_BUILD_LIBRARY_TYPE SHARED)
+endif()
+
 # Set project information
 project(AlexaClientSDK VERSION 1.22.0 LANGUAGES CXX)
 set(PROJECT_BRIEF "A cross-platform, modular SDK for interacting with the Alexa Voice Service")

--- a/CapabilitiesDelegate/src/CMakeLists.txt
+++ b/CapabilitiesDelegate/src/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.1 FATAL_ERROR)
 
 add_definitions("-DACSDK_LOG_MODULE=capabilitiesDelegate")
-add_library(CapabilitiesDelegate SHARED
+add_library(CapabilitiesDelegate ${AVS_DEVICE_SDK_BUILD_LIBRARY_TYPE}
     CapabilitiesDelegate.cpp
     DiscoveryEventSender.cpp
     PostConnectCapabilitiesPublisher.cpp

--- a/CapabilityAgents/AIP/src/CMakeLists.txt
+++ b/CapabilityAgents/AIP/src/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.1 FATAL_ERROR)
 
 add_definitions("-DACSDK_LOG_MODULE=aip")
-add_library(AIP SHARED
+add_library(AIP ${AVS_DEVICE_SDK_BUILD_LIBRARY_TYPE}
     AudioInputProcessor.cpp)
 target_include_directories(AIP PUBLIC
     "${AIP_SOURCE_DIR}/include"

--- a/CapabilityAgents/Alexa/src/CMakeLists.txt
+++ b/CapabilityAgents/Alexa/src/CMakeLists.txt
@@ -1,7 +1,7 @@
 add_definitions("-DACSDK_LOG_MODULE=alexa")
 
 add_library(
-        Alexa SHARED
+        Alexa ${AVS_DEVICE_SDK_BUILD_LIBRARY_TYPE}
         AlexaInterfaceCapabilityAgent.cpp
         AlexaInterfaceMessageSender.cpp
 )

--- a/CapabilityAgents/ApiGateway/src/CMakeLists.txt
+++ b/CapabilityAgents/ApiGateway/src/CMakeLists.txt
@@ -1,7 +1,7 @@
 add_definitions("-DACSDK_LOG_MODULE=apiGateway")
 
 add_library(
-        ApiGateway SHARED
+        ApiGateway ${AVS_DEVICE_SDK_BUILD_LIBRARY_TYPE}
         ApiGatewayCapabilityAgent.cpp
 )
 

--- a/CapabilityAgents/InteractionModel/src/CMakeLists.txt
+++ b/CapabilityAgents/InteractionModel/src/CMakeLists.txt
@@ -1,6 +1,6 @@
 add_definitions("-DACSDK_LOG_MODULE=interactionModel")
 
-add_library(InteractionModel SHARED
+add_library(InteractionModel ${AVS_DEVICE_SDK_BUILD_LIBRARY_TYPE}
         InteractionModelCapabilityAgent.cpp)
 
 target_include_directories(InteractionModel PUBLIC

--- a/CapabilityAgents/ModeController/src/CMakeLists.txt
+++ b/CapabilityAgents/ModeController/src/CMakeLists.txt
@@ -1,6 +1,6 @@
 add_definitions("-DACSDK_LOG_MODULE=modeController")
 
-add_library(ModeController SHARED
+add_library(ModeController ${AVS_DEVICE_SDK_BUILD_LIBRARY_TYPE}
     ModeControllerAttributeBuilder.cpp
     ModeControllerCapabilityAgent.cpp)
 

--- a/CapabilityAgents/PlaybackController/src/CMakeLists.txt
+++ b/CapabilityAgents/PlaybackController/src/CMakeLists.txt
@@ -1,6 +1,6 @@
 add_definitions("-DACSDK_LOG_MODULE=playbackcontroller")
 
-add_library(PlaybackController SHARED
+add_library(PlaybackController ${AVS_DEVICE_SDK_BUILD_LIBRARY_TYPE}
     "${CMAKE_CURRENT_LIST_DIR}/PlaybackController.cpp"
     "${CMAKE_CURRENT_LIST_DIR}/PlaybackControllerComponent.cpp"
     "${CMAKE_CURRENT_LIST_DIR}/PlaybackRouter.cpp"

--- a/CapabilityAgents/PowerController/src/CMakeLists.txt
+++ b/CapabilityAgents/PowerController/src/CMakeLists.txt
@@ -1,6 +1,6 @@
 add_definitions("-DACSDK_LOG_MODULE=powerController")
 
-add_library(PowerController SHARED
+add_library(PowerController ${AVS_DEVICE_SDK_BUILD_LIBRARY_TYPE}
     PowerControllerCapabilityAgent.cpp)
 
 target_include_directories(PowerController

--- a/CapabilityAgents/RangeController/src/CMakeLists.txt
+++ b/CapabilityAgents/RangeController/src/CMakeLists.txt
@@ -1,6 +1,6 @@
 add_definitions("-DACSDK_LOG_MODULE=rangeController")
 
-add_library(RangeController SHARED
+add_library(RangeController ${AVS_DEVICE_SDK_BUILD_LIBRARY_TYPE}
     RangeControllerAttributeBuilder.cpp
     RangeControllerCapabilityAgent.cpp)
 

--- a/CapabilityAgents/SoftwareComponentReporter/src/CMakeLists.txt
+++ b/CapabilityAgents/SoftwareComponentReporter/src/CMakeLists.txt
@@ -1,6 +1,6 @@
 add_definitions("-DACSDK_LOG_MODULE=SoftwareComponentReporter")
 
-add_library(SoftwareComponentReporter SHARED
+add_library(SoftwareComponentReporter ${AVS_DEVICE_SDK_BUILD_LIBRARY_TYPE}
     SoftwareComponentReporterCapabilityAgent.cpp)
 
 target_include_directories(SoftwareComponentReporter PUBLIC "${SoftwareComponentReporter_SOURCE_DIR}/include")

--- a/CapabilityAgents/SpeakerManager/src/CMakeLists.txt
+++ b/CapabilityAgents/SpeakerManager/src/CMakeLists.txt
@@ -1,6 +1,6 @@
 add_definitions("-DACSDK_LOG_MODULE=speakerManager")
 
-add_library(SpeakerManager SHARED SpeakerManager.cpp
+add_library(SpeakerManager ${AVS_DEVICE_SDK_BUILD_LIBRARY_TYPE} SpeakerManager.cpp
                                   ChannelVolumeManager.cpp
                                   DefaultChannelVolumeFactory.cpp
                                   SpeakerManagerComponent.cpp

--- a/CapabilityAgents/SpeechSynthesizer/src/CMakeLists.txt
+++ b/CapabilityAgents/SpeechSynthesizer/src/CMakeLists.txt
@@ -1,6 +1,6 @@
 add_definitions("-DACSDK_LOG_MODULE=speechSynthesizer")
 
-add_library(SpeechSynthesizer SHARED
+add_library(SpeechSynthesizer ${AVS_DEVICE_SDK_BUILD_LIBRARY_TYPE}
         SpeechSynthesizer.cpp)
 
 target_include_directories(SpeechSynthesizer PUBLIC

--- a/CapabilityAgents/System/src/CMakeLists.txt
+++ b/CapabilityAgents/System/src/CMakeLists.txt
@@ -1,6 +1,6 @@
 add_definitions("-DACSDK_LOG_MODULE=system")
 
-add_library(AVSSystem SHARED
+add_library(AVSSystem ${AVS_DEVICE_SDK_BUILD_LIBRARY_TYPE}
     "${CMAKE_CURRENT_LIST_DIR}/LocaleHandler.cpp"
     "${CMAKE_CURRENT_LIST_DIR}/ReportStateHandler.cpp"
     "${CMAKE_CURRENT_LIST_DIR}/SoftwareInfoSender.cpp"

--- a/CapabilityAgents/TemplateRuntime/src/CMakeLists.txt
+++ b/CapabilityAgents/TemplateRuntime/src/CMakeLists.txt
@@ -1,6 +1,6 @@
 add_definitions("-DACSDK_LOG_MODULE=templateRuntime")
 
-add_library(TemplateRuntime SHARED
+add_library(TemplateRuntime ${AVS_DEVICE_SDK_BUILD_LIBRARY_TYPE}
     "${CMAKE_CURRENT_LIST_DIR}/TemplateRuntime.cpp"
     "${CMAKE_CURRENT_LIST_DIR}/RenderPlayerInfoCardsProviderRegistrar.cpp")
 

--- a/CapabilityAgents/ToggleController/src/CMakeLists.txt
+++ b/CapabilityAgents/ToggleController/src/CMakeLists.txt
@@ -1,6 +1,6 @@
 add_definitions("-DACSDK_LOG_MODULE=toggleController")
 
-add_library(ToggleController SHARED
+add_library(ToggleController ${AVS_DEVICE_SDK_BUILD_LIBRARY_TYPE}
     ToggleControllerAttributeBuilder.cpp
     ToggleControllerCapabilityAgent.cpp)
 

--- a/Captions/Component/src/CMakeLists.txt
+++ b/Captions/Component/src/CMakeLists.txt
@@ -4,7 +4,7 @@ set(CaptionsComponent_SOURCES)
 list(APPEND CaptionsComponent_SOURCES
         CaptionsComponent.cpp)
 
-add_library(CaptionsComponent SHARED ${CaptionsComponent_SOURCES})
+add_library(CaptionsComponent ${AVS_DEVICE_SDK_BUILD_LIBRARY_TYPE} ${CaptionsComponent_SOURCES})
 
 target_include_directories(CaptionsComponent PUBLIC
         "${Captions_SOURCE_DIR}/Component/include")

--- a/Captions/Implementation/src/CMakeLists.txt
+++ b/Captions/Implementation/src/CMakeLists.txt
@@ -11,7 +11,7 @@ if (CAPTIONS)
     list(APPEND CaptionsLib_SOURCES LibwebvttParserAdapter.cpp)
 endif()
 
-add_library(CaptionsLib SHARED ${CaptionsLib_SOURCES})
+add_library(CaptionsLib ${AVS_DEVICE_SDK_BUILD_LIBRARY_TYPE} ${CaptionsLib_SOURCES})
 
 target_include_directories(CaptionsLib PUBLIC
         "${Captions_SOURCE_DIR}/Implementation/include")

--- a/Captions/Interface/src/CMakeLists.txt
+++ b/Captions/Interface/src/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_definitions("-DACSDK_LOG_MODULE=captions")
-add_library(Captions SHARED
+add_library(Captions ${AVS_DEVICE_SDK_BUILD_LIBRARY_TYPE}
         CaptionData.cpp
         CaptionLine.cpp
         CaptionFrame.cpp

--- a/CertifiedSender/src/CMakeLists.txt
+++ b/CertifiedSender/src/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_definitions("-DACSDK_LOG_MODULE=certifiedSender")
-add_library(CertifiedSender SHARED
+add_library(CertifiedSender ${AVS_DEVICE_SDK_BUILD_LIBRARY_TYPE}
         CertifiedSender.cpp
         SQLiteMessageStorage.cpp)
 

--- a/ContextManager/src/CMakeLists.txt
+++ b/ContextManager/src/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_definitions("-DACSDK_LOG_MODULE=contextManager")
-add_library(ContextManager SHARED
+add_library(ContextManager ${AVS_DEVICE_SDK_BUILD_LIBRARY_TYPE}
     ContextManager.cpp)
 
 target_include_directories(ContextManager PUBLIC

--- a/Diagnostics/src/CMakeLists.txt
+++ b/Diagnostics/src/CMakeLists.txt
@@ -1,6 +1,6 @@
 add_definitions("-DACSDK_LOG_MODULE=diagnostics")
 
-add_library(Diagnostics SHARED
+add_library(Diagnostics ${AVS_DEVICE_SDK_BUILD_LIBRARY_TYPE}
         DevicePropertyAggregator.cpp
         DiagnosticsUtils.cpp
         DeviceProtocolTracer.cpp

--- a/Endpoints/src/CMakeLists.txt
+++ b/Endpoints/src/CMakeLists.txt
@@ -1,6 +1,6 @@
 add_definitions("-DACSDK_LOG_MODULE=endpoints")
 
-add_library(Endpoints SHARED
+add_library(Endpoints ${AVS_DEVICE_SDK_BUILD_LIBRARY_TYPE}
         Endpoint.cpp
         EndpointAttributeValidation.cpp
         EndpointBuilder.cpp

--- a/InterruptModel/src/CMakeLists.txt
+++ b/InterruptModel/src/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.1 FATAL_ERROR)
 
 add_definitions("-DACSDK_LOG_MODULE=interruptModel")
 
-add_library(InterruptModel SHARED
+add_library(InterruptModel ${AVS_DEVICE_SDK_BUILD_LIBRARY_TYPE}
         InterruptModel.cpp
         "${InterruptModel_SOURCE_DIR}/config/src/InterruptModelConfiguration.cpp")
 

--- a/KWD/KWDProvider/src/CMakeLists.txt
+++ b/KWD/KWDProvider/src/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_library(KeywordDetectorProvider SHARED
+add_library(KeywordDetectorProvider ${AVS_DEVICE_SDK_BUILD_LIBRARY_TYPE}
     KeywordDetectorProvider.cpp)
 
 target_include_directories(KeywordDetectorProvider PUBLIC

--- a/KWD/KittAi/src/CMakeLists.txt
+++ b/KWD/KittAi/src/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_definitions("-DACSDK_LOG_MODULE=kittAiKeyWordDetector")
-add_library(KITTAI SHARED
+add_library(KITTAI ${AVS_DEVICE_SDK_BUILD_LIBRARY_TYPE}
     SnowboyWrapper.cpp
     KittAiKeyWordDetector.cpp)
 

--- a/KWD/Sensory/src/CMakeLists.txt
+++ b/KWD/Sensory/src/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_definitions("-DACSDK_LOG_MODULE=sensoryKeywordDetector")
-add_library(SENSORY SHARED
+add_library(SENSORY ${AVS_DEVICE_SDK_BUILD_LIBRARY_TYPE}
     SensoryKeywordDetector.cpp)
 
 target_include_directories(SENSORY PUBLIC

--- a/KWD/src/CMakeLists.txt
+++ b/KWD/src/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_definitions("-DACSDK_LOG_MODULE=abstractKeywordDetector")
-add_library(KWD SHARED
+add_library(KWD ${AVS_DEVICE_SDK_BUILD_LIBRARY_TYPE}
     AbstractKeywordDetector.cpp)
 
 include_directories(KWD "${KWD_SOURCE_DIR}/include")

--- a/MediaPlayer/AndroidSLESMediaPlayer/src/CMakeLists.txt
+++ b/MediaPlayer/AndroidSLESMediaPlayer/src/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_definitions("-DACSDK_LOG_MODULE=androidSLESMediaPlayer")
-add_library(AndroidSLESMediaPlayer SHARED
+add_library(AndroidSLESMediaPlayer ${AVS_DEVICE_SDK_BUILD_LIBRARY_TYPE}
         AndroidSLESMediaQueue.cpp
         AndroidSLESMediaPlayer.cpp
         AndroidSLESSpeaker.cpp

--- a/MediaPlayer/GStreamerMediaPlayer/src/CMakeLists.txt
+++ b/MediaPlayer/GStreamerMediaPlayer/src/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_definitions("-DACSDK_LOG_MODULE=mediaPlayer")
-add_library(MediaPlayer SHARED
+add_library(MediaPlayer ${AVS_DEVICE_SDK_BUILD_LIBRARY_TYPE}
     AttachmentReaderSource.cpp
     BaseStreamSource.cpp
     ErrorTypeConversion.cpp

--- a/Metrics/MetricRecorder/src/CMakeLists.txt
+++ b/Metrics/MetricRecorder/src/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_library(MetricRecorder SHARED MetricRecorder.cpp)
+add_library(MetricRecorder ${AVS_DEVICE_SDK_BUILD_LIBRARY_TYPE} MetricRecorder.cpp)
 
 target_include_directories(MetricRecorder	PUBLIC
 	"${MetricRecorder_SOURCE_DIR}/include"

--- a/Metrics/SampleMetricSink/src/CMakeLists.txt
+++ b/Metrics/SampleMetricSink/src/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_library(SampleMetricSink SHARED SampleMetricSink.cpp)
+add_library(SampleMetricSink ${AVS_DEVICE_SDK_BUILD_LIBRARY_TYPE} SampleMetricSink.cpp)
 
 target_include_directories(SampleMetricSink	PUBLIC
 	"${SampleMetricSink_SOURCE_DIR}/include"

--- a/Metrics/UplCalculator/src/CMakeLists.txt
+++ b/Metrics/UplCalculator/src/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_library(UplCalculator SHARED
+add_library(UplCalculator ${AVS_DEVICE_SDK_BUILD_LIBRARY_TYPE}
 	BaseUplCalculator.cpp
 	MediaUplCalculator.cpp
 	TtsUplCalculator.cpp

--- a/PlaylistParser/src/CMakeLists.txt
+++ b/PlaylistParser/src/CMakeLists.txt
@@ -1,6 +1,6 @@
 add_definitions("-DACSDK_LOG_MODULE=PlaylistParser")
 
-add_library(PlaylistParser SHARED
+add_library(PlaylistParser ${AVS_DEVICE_SDK_BUILD_LIBRARY_TYPE}
     ContentDecrypter.cpp
     FFMpegInputBuffer.cpp
     Id3TagsRemover.cpp

--- a/RegistrationManager/src/CMakeLists.txt
+++ b/RegistrationManager/src/CMakeLists.txt
@@ -1,6 +1,6 @@
 add_definitions("-DACSDK_LOG_MODULE=registrationManager")
 
-add_library(RegistrationManager SHARED RegistrationManager.cpp CustomerDataManager.cpp CustomerDataHandler.cpp)
+add_library(RegistrationManager ${AVS_DEVICE_SDK_BUILD_LIBRARY_TYPE} RegistrationManager.cpp CustomerDataManager.cpp CustomerDataHandler.cpp)
 
 target_include_directories(RegistrationManager PUBLIC
     "${RegistrationManager_SOURCE_DIR}/include")

--- a/SampleApp/Authorization/CBLAuthDelegate/src/CMakeLists.txt
+++ b/SampleApp/Authorization/CBLAuthDelegate/src/CMakeLists.txt
@@ -1,7 +1,7 @@
 find_package(Threads ${THREADS_PACKAGE_CONFIG})
 
 add_definitions("-DACSDK_LOG_MODULE=cblAuthDelegate")
-add_library(CBLAuthDelegate SHARED
+add_library(CBLAuthDelegate ${AVS_DEVICE_SDK_BUILD_LIBRARY_TYPE}
     CBLAuthDelegate.cpp
     CBLAuthDelegateConfiguration.cpp
     SQLiteCBLAuthDelegateStorage.cpp)

--- a/SampleApp/src/CMakeLists.txt
+++ b/SampleApp/src/CMakeLists.txt
@@ -59,7 +59,7 @@ if(EXTERNAL_MEDIA_ADAPTERS)
     list(APPEND LibSampleApp_SOURCES ${ALL_EMP_ADAPTER_REGISTRATION_FILES})
 endif ()
 
-add_library(LibSampleApp SHARED ${LibSampleApp_SOURCES})
+add_library(LibSampleApp ${AVS_DEVICE_SDK_BUILD_LIBRARY_TYPE} ${LibSampleApp_SOURCES})
 
 target_include_directories(LibSampleApp PUBLIC
         # This is relative to project(SampleApp).

--- a/SampleApp/src/CMakeLists.txt
+++ b/SampleApp/src/CMakeLists.txt
@@ -1,3 +1,5 @@
+option(BUILD_SAMPLE_APP "SampleApp application will be built with the libraries" ON)
+
 set(LibSampleApp_SOURCES)
 list(APPEND LibSampleApp_SOURCES
         CaptionPresenter.cpp
@@ -139,10 +141,13 @@ endif()
 
 add_rpath_to_target("LibSampleApp")
 
-add_executable(SampleApp
-        main.cpp)
+if (BUILD_SAMPLE_APP)
+    add_executable(SampleApp
+            main.cpp)
 
-target_link_libraries(SampleApp LibSampleApp)
+    target_link_libraries(SampleApp LibSampleApp)
+    asdk_install_targets(SampleApp TRUE)
+endif()
 
 # install target
 asdk_install_targets(LibSampleApp TRUE)

--- a/Settings/src/CMakeLists.txt
+++ b/Settings/src/CMakeLists.txt
@@ -1,7 +1,7 @@
 add_definitions("-DACSDK_LOG_MODULE=settings")
 
 
-add_library(DeviceSettings SHARED
+add_library(DeviceSettings ${AVS_DEVICE_SDK_BUILD_LIBRARY_TYPE}
         CloudControlledSettingProtocol.cpp
         DeviceControlledSettingProtocol.cpp
         SettingEventSender.cpp

--- a/SpeechEncoder/OpusEncoderContext/src/CMakeLists.txt
+++ b/SpeechEncoder/OpusEncoderContext/src/CMakeLists.txt
@@ -1,6 +1,6 @@
 add_definitions("-DACSDK_LOG_MODULE=opusEncoderContext")
 
-add_library(OpusEncoderContext SHARED
+add_library(OpusEncoderContext ${AVS_DEVICE_SDK_BUILD_LIBRARY_TYPE}
 OpusEncoderContext.cpp)
 
 find_path(OPUS_INCLUDE_DIR opus)

--- a/SpeechEncoder/src/CMakeLists.txt
+++ b/SpeechEncoder/src/CMakeLists.txt
@@ -1,6 +1,6 @@
 add_definitions("-DACSDK_LOG_MODULE=speechEncoder")
 
-add_library(SpeechEncoder SHARED
+add_library(SpeechEncoder ${AVS_DEVICE_SDK_BUILD_LIBRARY_TYPE}
 	SpeechEncoder.cpp
 )
 

--- a/Storage/SQLiteStorage/src/CMakeLists.txt
+++ b/Storage/SQLiteStorage/src/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_definitions("-DACSDK_LOG_MODULE=sqliteStorage")
-add_library(SQLiteStorage SHARED
+add_library(SQLiteStorage ${AVS_DEVICE_SDK_BUILD_LIBRARY_TYPE}
         SQLiteDatabase.cpp
         SQLiteMiscStorage.cpp
         SQLiteStatement.cpp

--- a/SynchronizeStateSender/src/CMakeLists.txt
+++ b/SynchronizeStateSender/src/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_definitions("-DACSDK_LOG_MODULE=synchronizeStateSender")
-add_library(SynchronizeStateSender SHARED
+add_library(SynchronizeStateSender ${AVS_DEVICE_SDK_BUILD_LIBRARY_TYPE}
         SynchronizeStateSenderFactory.cpp
         PostConnectSynchronizeStateSender.cpp)
 

--- a/applications/acsdkAndroidApplicationAudioPipelineFactory/src/CMakeLists.txt
+++ b/applications/acsdkAndroidApplicationAudioPipelineFactory/src/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.1 FATAL_ERROR)
 
 add_definitions("-DACSDK_LOG_MODULE=acsdkAndroidApplicationAudioPipelineFactory")
 
-add_library(acsdkAndroidApplicationAudioPipelineFactory SHARED
+add_library(acsdkAndroidApplicationAudioPipelineFactory ${AVS_DEVICE_SDK_BUILD_LIBRARY_TYPE}
         AndroidApplicationAudioPipelineFactory.cpp)
 
 target_include_directories(acsdkAndroidApplicationAudioPipelineFactory PUBLIC

--- a/applications/acsdkCBLAuthorizationDelegate/src/CMakeLists.txt
+++ b/applications/acsdkCBLAuthorizationDelegate/src/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_definitions("-DACSDK_LOG_MODULE=acsdkCBLAuthorizationDelegate")
-add_library(acsdkCBLAuthorizationDelegate SHARED
+add_library(acsdkCBLAuthorizationDelegate ${AVS_DEVICE_SDK_BUILD_LIBRARY_TYPE}
     AuthorizationDelegateComponent.cpp)
 
 target_include_directories(acsdkCBLAuthorizationDelegate PUBLIC

--- a/applications/acsdkCustomApplicationAudioPipelineFactory/src/CMakeLists.txt
+++ b/applications/acsdkCustomApplicationAudioPipelineFactory/src/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.1 FATAL_ERROR)
 
 add_definitions("-DACSDK_LOG_MODULE=acsdkCustomApplicationAudioPipelineFactory")
 
-add_library(acsdkCustomApplicationAudioPipelineFactory SHARED
+add_library(acsdkCustomApplicationAudioPipelineFactory ${AVS_DEVICE_SDK_BUILD_LIBRARY_TYPE}
         CustomApplicationAudioPipelineFactory.cpp)
 
 target_include_directories(acsdkCustomApplicationAudioPipelineFactory PUBLIC

--- a/applications/acsdkDefaultDeviceSettingsManager/src/CMakeLists.txt
+++ b/applications/acsdkDefaultDeviceSettingsManager/src/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_definitions("-DACSDK_LOG_MODULE=acsdkDefaultDeviceSettingsManager")
-add_library(acsdkDefaultDeviceSettingsManager SHARED
+add_library(acsdkDefaultDeviceSettingsManager ${AVS_DEVICE_SDK_BUILD_LIBRARY_TYPE}
         DeviceSettingsManagerBuilder.cpp
         DeviceSettingsManagerComponent.cpp)
 

--- a/applications/acsdkDefaultInternetConnectionMonitor/src/CMakeLists.txt
+++ b/applications/acsdkDefaultInternetConnectionMonitor/src/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_definitions("-DACSDK_LOG_MODULE=acsdkDefaultInternetConnectionMonitor")
-add_library(acsdkDefaultInternetConnectionMonitor SHARED
+add_library(acsdkDefaultInternetConnectionMonitor ${AVS_DEVICE_SDK_BUILD_LIBRARY_TYPE}
     InternetConnectionMonitorComponent.cpp)
 
 target_include_directories(acsdkDefaultInternetConnectionMonitor PUBLIC

--- a/applications/acsdkDefaultSampleApplicationOptions/src/CMakeLists.txt
+++ b/applications/acsdkDefaultSampleApplicationOptions/src/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_definitions("-DACSDK_LOG_MODULE=acsdkDefaultSampleApplicationOptions")
-add_library(acsdkDefaultSampleApplicationOptions SHARED
+add_library(acsdkDefaultSampleApplicationOptions ${AVS_DEVICE_SDK_BUILD_LIBRARY_TYPE}
         DefaultSampleApplicationOptionsComponent.cpp)
 
 target_include_directories(acsdkDefaultSampleApplicationOptions PUBLIC

--- a/applications/acsdkGstreamerApplicationAudioPipelineFactory/src/CMakeLists.txt
+++ b/applications/acsdkGstreamerApplicationAudioPipelineFactory/src/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.1 FATAL_ERROR)
 
 add_definitions("-DACSDK_LOG_MODULE=acsdkGstreamerApplicationAudioPipelineFactory")
 
-add_library(acsdkGstreamerApplicationAudioPipelineFactory SHARED
+add_library(acsdkGstreamerApplicationAudioPipelineFactory ${AVS_DEVICE_SDK_BUILD_LIBRARY_TYPE}
         GstreamerApplicationAudioPipelineFactory.cpp)
 
 target_include_directories(acsdkGstreamerApplicationAudioPipelineFactory PUBLIC

--- a/applications/acsdkLibcurlAlexaCommunications/src/CMakeLists.txt
+++ b/applications/acsdkLibcurlAlexaCommunications/src/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_definitions("-DACSDK_LOG_MODULE=acsdkLibcurlAlexaCommunications")
-add_library(acsdkLibcurlAlexaCommunications SHARED
+add_library(acsdkLibcurlAlexaCommunications ${AVS_DEVICE_SDK_BUILD_LIBRARY_TYPE}
         AlexaCommunicationsComponent.cpp)
 
 target_include_directories(acsdkLibcurlAlexaCommunications PUBLIC

--- a/applications/acsdkLibcurlHTTPContentFetcher/src/CMakeLists.txt
+++ b/applications/acsdkLibcurlHTTPContentFetcher/src/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_definitions("-DACSDK_LOG_MODULE=acsdkLibcurlHTTPContentFetcher")
-add_library(acsdkLibcurlHTTPContentFetcher SHARED
+add_library(acsdkLibcurlHTTPContentFetcher ${AVS_DEVICE_SDK_BUILD_LIBRARY_TYPE}
     HTTPContentFetcherComponent.cpp)
 
 target_include_directories(acsdkLibcurlHTTPContentFetcher PUBLIC

--- a/applications/acsdkNullMetricRecorder/src/CMakeLists.txt
+++ b/applications/acsdkNullMetricRecorder/src/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_definitions("-DACSDK_LOG_MODULE=acsdkNullMetricRecorder")
-add_library(acsdkNullMetricRecorder SHARED
+add_library(acsdkNullMetricRecorder ${AVS_DEVICE_SDK_BUILD_LIBRARY_TYPE}
     MetricRecorderComponent.cpp)
 
 target_include_directories(acsdkNullMetricRecorder PUBLIC

--- a/applications/acsdkNullSystemTimeZone/src/CMakeLists.txt
+++ b/applications/acsdkNullSystemTimeZone/src/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_definitions("-DACSDK_LOG_MODULE=acsdkNullSystemTimeZone")
-add_library(acsdkNullSystemTimeZone SHARED
+add_library(acsdkNullSystemTimeZone ${AVS_DEVICE_SDK_BUILD_LIBRARY_TYPE}
         SystemTimeZoneComponent.cpp)
 
 target_include_directories(acsdkNullSystemTimeZone PUBLIC

--- a/applications/acsdkPreviewAlexaClient/src/CMakeLists.txt
+++ b/applications/acsdkPreviewAlexaClient/src/CMakeLists.txt
@@ -3,7 +3,7 @@ list(APPEND LibPreviewAlexaClient_SOURCES
         PreviewAlexaClient.cpp
         PreviewAlexaClientComponent.cpp)
 
-add_library(LibPreviewAlexaClient SHARED ${LibPreviewAlexaClient_SOURCES})
+add_library(LibPreviewAlexaClient ${AVS_DEVICE_SDK_BUILD_LIBRARY_TYPE} ${LibPreviewAlexaClient_SOURCES})
 
 target_include_directories(LibPreviewAlexaClient PUBLIC
         "${acsdkPreviewAlexaClient_SOURCE_DIR}/include")

--- a/applications/acsdkSampleApplicationCBLAuthRequester/src/CMakeLists.txt
+++ b/applications/acsdkSampleApplicationCBLAuthRequester/src/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_definitions("-DACSDK_LOG_MODULE=acsdkSampleApplicationCBLAuthRequester")
-add_library(acsdkSampleApplicationCBLAuthRequester SHARED
+add_library(acsdkSampleApplicationCBLAuthRequester ${AVS_DEVICE_SDK_BUILD_LIBRARY_TYPE}
     SampleApplicationCBLAuthRequester.cpp)
 
 target_include_directories(acsdkSampleApplicationCBLAuthRequester PUBLIC

--- a/capabilities/Alerts/acsdkAlerts/src/CMakeLists.txt
+++ b/capabilities/Alerts/acsdkAlerts/src/CMakeLists.txt
@@ -1,6 +1,6 @@
 add_definitions("-DACSDK_LOG_MODULE=alerts")
 
-add_library(acsdkAlerts SHARED
+add_library(acsdkAlerts ${AVS_DEVICE_SDK_BUILD_LIBRARY_TYPE}
         Renderer/Renderer.cpp
         Storage/SQLiteAlertStorage.cpp
         Alarm.cpp

--- a/capabilities/AudioPlayer/acsdkAudioPlayer/src/CMakeLists.txt
+++ b/capabilities/AudioPlayer/acsdkAudioPlayer/src/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_definitions("-DACSDK_LOG_MODULE=audioplayer")
-add_library(acsdkAudioPlayer SHARED
+add_library(acsdkAudioPlayer ${AVS_DEVICE_SDK_BUILD_LIBRARY_TYPE}
     AudioPlayer.cpp
     AudioPlayerComponent.cpp
     ProgressTimer.cpp)

--- a/capabilities/Bluetooth/acsdkBluetooth/src/CMakeLists.txt
+++ b/capabilities/Bluetooth/acsdkBluetooth/src/CMakeLists.txt
@@ -1,7 +1,7 @@
 add_definitions("-DACSDK_LOG_MODULE=bluetooth")
 
 add_library(
-    acsdkBluetooth SHARED
+    acsdkBluetooth ${AVS_DEVICE_SDK_BUILD_LIBRARY_TYPE}
     BasicDeviceConnectionRule.cpp
     Bluetooth.cpp
     BluetoothEventState.cpp

--- a/capabilities/DoNotDisturb/acsdkDoNotDisturb/src/CMakeLists.txt
+++ b/capabilities/DoNotDisturb/acsdkDoNotDisturb/src/CMakeLists.txt
@@ -1,6 +1,6 @@
 add_definitions("-DACSDK_LOG_MODULE=acsdkDoNotDisturb")
 
-add_library(acsdkDoNotDisturb SHARED
+add_library(acsdkDoNotDisturb ${AVS_DEVICE_SDK_BUILD_LIBRARY_TYPE}
         DNDMessageRequest.cpp
         DNDSettingProtocol.cpp
         DoNotDisturbCapabilityAgent.cpp

--- a/capabilities/Equalizer/acsdkEqualizer/src/CMakeLists.txt
+++ b/capabilities/Equalizer/acsdkEqualizer/src/CMakeLists.txt
@@ -1,6 +1,6 @@
 add_definitions("-DACSDK_LOG_MODULE=equalizer")
 
-add_library(acsdkEqualizer SHARED
+add_library(acsdkEqualizer ${AVS_DEVICE_SDK_BUILD_LIBRARY_TYPE}
         EqualizerCapabilityAgent.cpp)
 
 target_include_directories(acsdkEqualizer PUBLIC

--- a/capabilities/Equalizer/acsdkEqualizerImplementations/src/CMakeLists.txt
+++ b/capabilities/Equalizer/acsdkEqualizerImplementations/src/CMakeLists.txt
@@ -1,6 +1,6 @@
 add_definitions("-DACSDK_LOG_MODULE=equalizer")
 
-add_library(acsdkEqualizerImplementations SHARED
+add_library(acsdkEqualizerImplementations ${AVS_DEVICE_SDK_BUILD_LIBRARY_TYPE}
         EqualizerComponent.cpp
         EqualizerController.cpp
         EqualizerUtils.cpp

--- a/capabilities/ExternalMediaPlayer/acsdkExternalMediaPlayer/src/CMakeLists.txt
+++ b/capabilities/ExternalMediaPlayer/acsdkExternalMediaPlayer/src/CMakeLists.txt
@@ -1,6 +1,6 @@
 add_definitions("-DACSDK_LOG_MODULE=ExternalMediaPlayer")
 
-add_library(acsdkExternalMediaPlayer SHARED
+add_library(acsdkExternalMediaPlayer ${AVS_DEVICE_SDK_BUILD_LIBRARY_TYPE}
     AuthorizedSender.cpp
     ExternalMediaAdapterHandler.cpp
     ExternalMediaPlayer.cpp

--- a/capabilities/ExternalMediaPlayer/acsdkExternalMediaPlayerInterfaces/src/CMakeLists.txt
+++ b/capabilities/ExternalMediaPlayer/acsdkExternalMediaPlayerInterfaces/src/CMakeLists.txt
@@ -1,6 +1,6 @@
 include(${AVS_CORE}/build/BuildDefaults.cmake)
 
-add_library(acsdkExternalMediaPlayerInterfaces SHARED
+add_library(acsdkExternalMediaPlayerInterfaces ${AVS_DEVICE_SDK_BUILD_LIBRARY_TYPE}
     AdapterUtils.cpp)
 
 target_include_directories(acsdkExternalMediaPlayerInterfaces PUBLIC

--- a/capabilities/MultiRoomMusic/acsdkMultiRoomMusic/src/CMakeLists.txt
+++ b/capabilities/MultiRoomMusic/acsdkMultiRoomMusic/src/CMakeLists.txt
@@ -1,6 +1,6 @@
 add_definitions("-DACSDK_LOG_MODULE=acsdkMultiRoomMusic")
 
-add_library(acsdkMultiRoomMusic SHARED
+add_library(acsdkMultiRoomMusic ${AVS_DEVICE_SDK_BUILD_LIBRARY_TYPE}
         MRMCapabilityAgent.cpp)
 
 target_include_directories(acsdkMultiRoomMusic PUBLIC

--- a/capabilities/Notifications/acsdkNotifications/src/CMakeLists.txt
+++ b/capabilities/Notifications/acsdkNotifications/src/CMakeLists.txt
@@ -1,6 +1,6 @@
 add_definitions("-DACSDK_LOG_MODULE=Notifications")
 
-add_library(acsdkNotifications SHARED
+add_library(acsdkNotifications ${AVS_DEVICE_SDK_BUILD_LIBRARY_TYPE}
 		NotificationIndicator.cpp
 		NotificationRenderer.cpp
 		NotificationsCapabilityAgent.cpp

--- a/core/acsdkCore/src/CMakeLists.txt
+++ b/core/acsdkCore/src/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_definitions("-DACSDK_LOG_MODULE=acsdkCore")
-add_library(acsdkCore SHARED
+add_library(acsdkCore ${AVS_DEVICE_SDK_BUILD_LIBRARY_TYPE}
     CoreComponent.cpp)
 
 target_include_directories(acsdkCore PUBLIC

--- a/core/acsdkPostConnectOperationProviderRegistrar/src/CMakeLists.txt
+++ b/core/acsdkPostConnectOperationProviderRegistrar/src/CMakeLists.txt
@@ -1,6 +1,6 @@
 add_definitions("-DACSDK_LOG_MODULE=acsdkPostConnectOperationProviderRegistrar")
 
-add_library(acsdkPostConnectOperationProviderRegistrar SHARED
+add_library(acsdkPostConnectOperationProviderRegistrar ${AVS_DEVICE_SDK_BUILD_LIBRARY_TYPE}
     PostConnectOperationProviderRegistrar.cpp)
 
 target_include_directories(acsdkPostConnectOperationProviderRegistrar PUBLIC

--- a/shared/acsdkManufactory/src/CMakeLists.txt
+++ b/shared/acsdkManufactory/src/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.1 FATAL_ERROR)
 add_definitions("-DACSDK_LOG_MODULE=Manufactory")
 
-add_library(acsdkManufactory SHARED
+add_library(acsdkManufactory ${AVS_DEVICE_SDK_BUILD_LIBRARY_TYPE}
     CookBook.cpp)
 
 target_link_libraries(acsdkManufactory AVSCommon)

--- a/shared/acsdkShared/src/CMakeLists.txt
+++ b/shared/acsdkShared/src/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_definitions("-DACSDK_LOG_MODULE=acsdkShared")
-add_library(acsdkShared SHARED
+add_library(acsdkShared ${AVS_DEVICE_SDK_BUILD_LIBRARY_TYPE}
     SharedComponent.cpp)
 
 target_include_directories(acsdkShared PUBLIC

--- a/shared/acsdkShutdownManager/src/CMakeLists.txt
+++ b/shared/acsdkShutdownManager/src/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_definitions("-DACSDK_LOG_MODULE=acsdkShutdownManager")
-add_library(acsdkShutdownManager SHARED
+add_library(acsdkShutdownManager ${AVS_DEVICE_SDK_BUILD_LIBRARY_TYPE}
     ShutdownManager.cpp)
 
 target_include_directories(acsdkShutdownManager PUBLIC

--- a/shared/acsdkStartupManager/src/CMakeLists.txt
+++ b/shared/acsdkStartupManager/src/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_definitions("-DACSDK_LOG_MODULE=acsdkStartupManager")
-add_library(acsdkStartupManager SHARED
+add_library(acsdkStartupManager ${AVS_DEVICE_SDK_BUILD_LIBRARY_TYPE}
     StartupManager.cpp)
 
 target_include_directories(acsdkStartupManager PUBLIC


### PR DESCRIPTION
The issue in ability to build this project as a bunch of static libraries, and ability to switch off building SampleApp application(for example when libraries only needed). 

Added a global option "BUILD_STATIC_LIBS" and in addition "BUILD_SAMPLE_APP" in the SampleApp/CMakeLists.txt.
It can be used by passing this options to cmake on generation stage.
For example this parameters will produce build system with static library building only and executable.
    -DBUILD_STATIC_LIBS=ON
    -DBUILD_SAMPLE_APP=OFF

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
