### PR TITLE
Use pip3 instead of pip

### DIFF
--- a/tools/Install/pi.sh
+++ b/tools/Install/pi.sh
@@ -35,7 +35,7 @@ GSTREAMER_AUDIO_SINK="alsasink"
 install_dependencies() {
   sudo apt-get update
   sudo apt-get -y install git gcc cmake build-essential libsqlite3-dev libssl-dev libnghttp2-dev libfaad-dev libsoup2.4-dev libgcrypt20-dev libgstreamer-plugins-bad1.0-dev gstreamer1.0-plugins-good libasound2-dev sox gedit vim python3-pip
-  pip install flask commentjson
+  pip3 install flask commentjson
 }
 
 run_os_specifics() {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
pip for python 2.7 is not installed


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
