### PR TITLE
fix mingw64 error: invalid linker name in argument '-fuse-ld=lld'

### DIFF
--- a/tools/Install/mingw.sh
+++ b/tools/Install/mingw.sh
@@ -34,7 +34,7 @@ install_dependencies() {
   PACMAN_ARGS="--noconfirm --needed"
 
   # Build tools and make (mingw32-make fails building portAudio)
-  pacman -S ${PACMAN_ARGS} git mingw-w64-x86_64-toolchain mingw-w64-x86_64-clang mingw-w64-x86_64-cmake msys/tar msys/make
+  pacman -S ${PACMAN_ARGS} git mingw-w64-x86_64-toolchain mingw-w64-x86_64-clang mingw-w64-x86_64-cmake mingw-w64-x86_64-lld msys/tar msys/make
 
   # required by the SDK
   pacman -S ${PACMAN_ARGS} mingw-w64-x86_64-sqlite3


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/alexa/avs-device-sdk/issues/2033
*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
