### PR TITLE
Fix build error in avs-device-sdk std move function

### DIFF
--- a/AVSCommon/Utils/src/WorkerThread.cpp
+++ b/AVSCommon/Utils/src/WorkerThread.cpp
@@ -53,7 +53,7 @@ std::thread::id WorkerThread::getThreadId() const {
 void WorkerThread::run(std::function<bool()> workFunc) {
     std::lock_guard<std::mutex> lock(m_mutex);
     m_cancel = false;
-    m_workerFunc = move(workFunc);
+    m_workerFunc = std::move(workFunc);
     m_workReady.notify_one();
 }
 

--- a/AVSGatewayManager/src/AuthRefreshedObserver.cpp
+++ b/AVSGatewayManager/src/AuthRefreshedObserver.cpp
@@ -39,7 +39,7 @@ static const string TAG("AuthRefreshedObserver");
 
 AuthRefreshedObserver::AuthRefreshedObserver(function<void()> afterAuthRefreshedCallback) :
         m_state{State::UNINITIALIZED},
-        m_afterAuthRefreshedCallback{move(afterAuthRefreshedCallback)} {
+        m_afterAuthRefreshedCallback{std::move(afterAuthRefreshedCallback)} {
 }
 
 shared_ptr<AuthRefreshedObserver> alexaClientSDK::avsGatewayManager::AuthRefreshedObserver::create(


### PR DESCRIPTION

*Description of changes:*
Currently the build fails with ```error: unqualified call to 'std::move'```

Appending the std namespace to the function resolves it.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
